### PR TITLE
[bug] fix attribute access in srpregister tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
   - python ~/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/pyside_postinstall.py -install
 
 script:
-  - sh pkg/postmkenv.sh
   - python setup.py test
 
 after_success:

--- a/src/leap/bitmask/crypto/srpregister.py
+++ b/src/leap/bitmask/crypto/srpregister.py
@@ -205,6 +205,22 @@ class SRPRegister(QtCore.QObject):
         else:
             self._signaler.signal(self._signaler.srp_registration_failed)
 
+    @property
+    def registration_uri(self):
+        """
+        Return the uri used for registration.
+        :rtype: str
+        """
+        return self._srp_register._get_registration_uri()
+
+    @property
+    def port(self):
+        """
+        Return the port used for registration.
+        :rtype: str
+        """
+        return self._srp_register._port
+
 
 if __name__ == "__main__":
     logger = logging.getLogger(name='leap')

--- a/src/leap/bitmask/crypto/tests/test_srpregister.py
+++ b/src/leap/bitmask/crypto/tests/test_srpregister.py
@@ -112,7 +112,7 @@ class SRPTestCase(unittest.TestCase):
                 "Could not load test provider config")
 
         register = srpregister.SRPRegister(provider_config=provider)
-        self.assertEquals(register._port, "443")
+        self.assertEquals(register.port, "443")
 
     @deferred()
     def test_wrong_cert(self):
@@ -191,9 +191,10 @@ class SRPTestCase(unittest.TestCase):
 
         # ... and we check that we're correctly taking the HTTPS protocol
         # instead
-        reg_uri = register._get_registration_uri()
+        reg_uri = register.registration_uri
         self.assertEquals(reg_uri, HTTPS_URI)
-        register._get_registration_uri = MagicMock(return_value=HTTPS_URI)
+        # XXX hack. this shouldn't mess with implementation details!
+        register._srp_register._get_registration_uri = MagicMock(return_value=HTTPS_URI)
         d = threads.deferToThread(register.register_user, "test_failhttp",
                                   "barpass")
         d.addCallback(self.assertTrue)


### PR DESCRIPTION
After the last refactor, tests were not updated to access a couple of
attributes that remained in SRPRegisterImpl.

This commit fixes this, by making the registration_uri and port two
public attributes of SRPRegister. Therefore, all tests should be passing
now.

P.S. Previous PR wasn't detected by Travis. It seems I must not update the branch against with the PR is opened, because Travis will ignore the PR. Let's see what happens with this one.
